### PR TITLE
Fix "global" argument for Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ Meta/*
 paper/paper.docx
 /paper/paper_cache/
 paper/*.Rout
+
+# Mac Specific
+*.DS_Store
+/.Rproj.user

--- a/R/wdpa_fetch.R
+++ b/R/wdpa_fetch.R
@@ -157,10 +157,12 @@ wdpa_fetch <- function(x, wait = FALSE,
                        datatype = "gdb",
                        verbose = interactive()) {
   # check that arguments are valid
+  ## expand path to ensure full path to folder
+  assertthat::assert_that(
+    assertthat::is.string(download_dir),
+    assertthat::noNA(download_dir))
+  download_dir <- path.expand(download_dir)
   ## check that classes are correct
-  # rappdirs::user_data_dir() returns a directory starting with ~/ for Mac, which causes the unzip to fail. Here we expand to remove ~. Shouldn't make any diffferent to other OS's where the path is already expanded.
-  download_dir <- path.expand(download_dir) 
-  dir.create(download_dir, showWarnings = FALSE, recursive = TRUE)
   assertthat::assert_that(
     assertthat::is.string(x),
     assertthat::is.dir(download_dir),
@@ -168,6 +170,7 @@ wdpa_fetch <- function(x, wait = FALSE,
     assertthat::is.flag(verbose),
     assertthat::is.flag(check_version),
     identical(x, "global") || assertthat::is.string(country_code(x)))
+  dir.create(download_dir, showWarnings = FALSE, recursive = TRUE)
   # try to find locally on system
   file_path <- try(wdpa_file(x, download_dir = download_dir), silent = TRUE)
   # fetch data

--- a/R/wdpa_fetch.R
+++ b/R/wdpa_fetch.R
@@ -162,6 +162,7 @@ wdpa_fetch <- function(x, wait = FALSE,
     assertthat::is.string(download_dir),
     assertthat::noNA(download_dir))
   download_dir <- path.expand(download_dir)
+  dir.create(download_dir, showWarnings = FALSE, recursive = TRUE)
   ## check that classes are correct
   assertthat::assert_that(
     assertthat::is.string(x),
@@ -170,7 +171,6 @@ wdpa_fetch <- function(x, wait = FALSE,
     assertthat::is.flag(verbose),
     assertthat::is.flag(check_version),
     identical(x, "global") || assertthat::is.string(country_code(x)))
-  dir.create(download_dir, showWarnings = FALSE, recursive = TRUE)
   # try to find locally on system
   file_path <- try(wdpa_file(x, download_dir = download_dir), silent = TRUE)
   # fetch data

--- a/R/wdpa_fetch.R
+++ b/R/wdpa_fetch.R
@@ -158,6 +158,8 @@ wdpa_fetch <- function(x, wait = FALSE,
                        verbose = interactive()) {
   # check that arguments are valid
   ## check that classes are correct
+  # rappdirs::user_data_dir() returns a directory starting with ~/ for Mac, which causes the unzip to fail. Here we expand to remove ~. Shouldn't make any diffferent to other OS's where the path is already expanded.
+  download_dir <- path.expand(download_dir) 
   dir.create(download_dir, showWarnings = FALSE, recursive = TRUE)
   assertthat::assert_that(
     assertthat::is.string(x),

--- a/R/wdpa_read.R
+++ b/R/wdpa_read.R
@@ -64,7 +64,7 @@ wdpa_read <- function(x, n = NULL) {
   # unzip the folder
   tdir <- file.path(tempdir(), basename(tempfile()))
   dir.create(tdir, showWarnings = FALSE, recursive = TRUE)
-  utils::unzip(x, exdir = tdir)
+  utils::unzip(x, exdir = tdir, unzip = getOption("unzip"))
   # determine version
   month_year <- strsplit(basename(x), "_", fixed = TRUE)[[1]][[2]]
   # load data


### PR DESCRIPTION
This seems to work on 2 x MBPs (M1Max and M2Pro)

Including the getOption seemed to solve the unzip issue. rappdirs returned a ~ for the home directory which then didn't work with the unzip, so I added a expand.path

closes #79 